### PR TITLE
Removed Cocktail Description

### DIFF
--- a/src/views/Cocktails.vue
+++ b/src/views/Cocktails.vue
@@ -91,7 +91,7 @@
             </template>
             <span v-else>{{ r.decoration }}</span>
           </div>
-          <p>{{ r.description }}</p>
+
         </a-card>
       </a-col>
     </a-row>


### PR DESCRIPTION
I have removed the description text from the cocktail cards on the main list page to make the cards more compact.

Changes
Frontend
Cocktails.vue: Removed the <p>{{ r.description }}</p> element from the cocktail card template.