### PR TITLE
Equalized Cocktail Card Heights

### DIFF
--- a/src/views/Cocktails.vue
+++ b/src/views/Cocktails.vue
@@ -16,7 +16,7 @@
 
     <a-row :gutter="[16, 16]">
       <a-col v-for="r in filteredRecipes" :key="r._id" :xs="24" :sm="12" :md="8">
-        <a-card>
+        <a-card class="h-full">
           <template #extra>
             <a-dropdown trigger="click">
               <a class="ant-dropdown-link" @click.prevent>


### PR DESCRIPTION
I have updated the cocktail cards styling to ensure they all have the same height within each row, improving the visual consistency of the grid layout.

**Changes**

Cocktails.vue: Added class="h-full" to the a-card component. This forces the card to take up the full available height of its grid column.