### PR TITLE
Cocktail Category Display Refactor

### DIFF
--- a/src/views/Cocktails.vue
+++ b/src/views/Cocktails.vue
@@ -50,10 +50,10 @@
           </template>
           <template #title>
             <router-link :to="`/cocktails/${r._id}`" class="flex items-center gap-2">
-              <span>{{ r.name }}</span>
-              <a-tag :color="r.category === 'Classic' ? 'blue' : 'purple'">
-                {{ r.category }}
+              <a-tag :color="r.category === 'Classic' ? 'blue' : 'purple'" :title="r.category">
+                {{ r.category[0] }}
               </a-tag>
+              <span>{{ r.name }}</span>
             </router-link>
           </template>
 


### PR DESCRIPTION
I have updated the cocktail cards to display the category in a more compact and visually appealing way.

### Changes

**Cocktails.vue:**
Moved the category chip to the left of the cocktail name.
Shortened the category text to a single letter ("C" for Classic, "S" for Signature).
Added a tooltip that shows the full category name when hovering over the letter.