### PR TITLE
Removed Table Header

### DIFF
--- a/src/views/Cocktails.vue
+++ b/src/views/Cocktails.vue
@@ -73,6 +73,7 @@
             :data-source="r.components"
             size="small"
             :pagination="false"
+            :showHeader="false"
             bordered
           />
 


### PR DESCRIPTION
I have removed the header row from the ingredients table within the cocktail cards to create a cleaner and more compact look.

### Changes

**Cocktails.vue:** Added the :showHeader="false" prop to the a-table component in the cocktail card template.