### PR TITLE
Restructured Cocktail Card Footer

### DIFF
--- a/src/views/Cocktails.vue
+++ b/src/views/Cocktails.vue
@@ -16,7 +16,7 @@
 
     <a-row :gutter="[16, 16]">
       <a-col v-for="r in filteredRecipes" :key="r._id" :xs="24" :sm="12" :md="8">
-        <a-card class="h-full">
+        <a-card class="h-full flex flex-col" :bodyStyle="{ flex: '1', display: 'flex', flexDirection: 'column' }">
           <template #extra>
             <a-dropdown trigger="click">
               <a class="ant-dropdown-link" @click.prevent>
@@ -57,42 +57,45 @@
             </router-link>
           </template>
 
-          <div class="mb-3">
-            <img
-              :src="r.image || placeholderImage"
-              alt="cocktail image"
-              class="w-full h-48 object-cover rounded"
+          <div class="flex-1">
+            <div class="mb-3">
+              <img
+                :src="r.image || placeholderImage"
+                alt="cocktail image"
+                class="w-full h-48 object-cover rounded"
+              />
+            </div>
+
+            <a-table
+              :columns="[
+                { title: 'Ингредиент', dataIndex: 'name', key: 'name' },
+                { title: 'Количество (мл)', dataIndex: 'amount', key: 'amount' }
+              ]"
+              :data-source="r.components"
+              size="small"
+              :pagination="false"
+              :showHeader="false"
+              bordered
             />
           </div>
 
-          <a-table
-            :columns="[
-              { title: 'Ингредиент', dataIndex: 'name', key: 'name' },
-              { title: 'Количество (мл)', dataIndex: 'amount', key: 'amount' }
-            ]"
-            :data-source="r.components"
-            size="small"
-            :pagination="false"
-            :showHeader="false"
-            bordered
-          />
-
-          <div class="mt-2">
-            <strong>Метод:</strong>
-            <template v-if="Array.isArray(r.method)">
-              <a-tag v-for="m in r.method" :key="m" color="blue">{{ m }}</a-tag>
-            </template>
-            <span v-else>{{ r.method }}</span>
+          <div class="mt-auto pt-4 border-t border-gray-200">
+            <div class="mb-2">
+              <strong>Метод:</strong>
+              <template v-if="Array.isArray(r.method)">
+                <a-tag v-for="m in r.method" :key="m" color="blue">{{ m }}</a-tag>
+              </template>
+              <span v-else>{{ r.method }}</span>
+            </div>
+            <div class="mb-2"><strong>Бокал:</strong> {{ r.glass }}</div>
+            <div>
+              <strong>Украшение:</strong>
+              <template v-if="Array.isArray(r.decoration)">
+                <a-tag v-for="d in r.decoration" :key="d" color="green">{{ d }}</a-tag>
+              </template>
+              <span v-else>{{ r.decoration }}</span>
+            </div>
           </div>
-          <p><strong>Бокал:</strong> {{ r.glass }}</p>
-          <div class="mt-2">
-            <strong>Украшение:</strong>
-            <template v-if="Array.isArray(r.decoration)">
-              <a-tag v-for="d in r.decoration" :key="d" color="green">{{ d }}</a-tag>
-            </template>
-            <span v-else>{{ r.decoration }}</span>
-          </div>
-
         </a-card>
       </a-col>
     </a-row>


### PR DESCRIPTION
I have updated the cocktail card layout to include a dedicated footer section for the preparation details (Method, Glass, Decoration). This footer is aligned to the bottom of the card and separated by a line.

### Changes

**Cocktails.vue:**
Updated the card layout to use flexbox (flex flex-col).
Grouped the "Method", "Glass", and "Decoration" sections into a footer div.
Applied mt-auto to the footer to push it to the bottom of the card.
Added a top border (border-t) to visually separate the footer from the ingredients list.