### PR TITLE
Fixed Filter Placeholders

### DIFF
--- a/src/components/CocktailFilter.vue
+++ b/src/components/CocktailFilter.vue
@@ -89,11 +89,11 @@ import { COMPONENTS_URL, METHODS_URL, GLASSES_URL, DECORATIONS_URL } from '../co
 import { useAuthStore } from '../stores/auth';
 
 const filters = ref({
-  category: "",
-  component: "",
-  glass: "",
-  method: "",
-  decoration: "",
+  category: undefined,
+  component: undefined,
+  glass: undefined,
+  method: undefined,
+  decoration: undefined,
 })
 
 const components = ref([])
@@ -141,7 +141,7 @@ const applyFilters = () => {
 }
 
 const resetFilters = () => {
-  filters.value = { category: "", component: "", glass: "", method: "", decoration: "" }
+  filters.value = { category: undefined, component: undefined, glass: undefined, method: undefined, decoration: undefined }
   applyFilters()
 }
 


### PR DESCRIPTION
I have fixed the issue where placeholders were not displaying in the cocktail filters. This was caused by initializing the filter values to empty strings instead of undefined.

### Changes

**CocktailFilter.vue:**
Updated the filters ref initialization to set all fields to undefined.
Updated 
resetFilters
 to reset all fields to undefined.