### PR TITLE
Removed Table Border

### DIFF
--- a/src/views/Cocktails.vue
+++ b/src/views/Cocktails.vue
@@ -75,7 +75,6 @@
               size="small"
               :pagination="false"
               :showHeader="false"
-              bordered
             />
           </div>
 


### PR DESCRIPTION
I have removed the outer border from the ingredients table within the cocktail cards to create a more seamless and cleaner appearance.

### Changes

**Cocktails.vue:** Removed the bordered prop from the a-table component in the cocktail card template.