### PR TITLE
Removed Last Row Border

### DIFF
--- a/src/views/Cocktails.vue
+++ b/src/views/Cocktails.vue
@@ -67,6 +67,7 @@
             </div>
 
             <a-table
+              class="ingredients-table"
               :columns="[
                 { title: 'Ингредиент', dataIndex: 'name', key: 'name' },
                 { title: 'Количество (мл)', dataIndex: 'amount', key: 'amount' }
@@ -146,3 +147,9 @@ const deleteRecipe = async (id) => {
 
 onMounted(fetchRecipes)
 </script>
+
+<style scoped>
+.ingredients-table :deep(.ant-table-tbody > tr:last-child > td) {
+  border-bottom: none !important;
+}
+</style>


### PR DESCRIPTION
I have removed the bottom border from the last row of the ingredients table in the cocktail cards. This creates a cleaner look where the table content blends seamlessly with the card footer.

### Changes

**Cocktails.vue:**
Added class="ingredients-table" to the a-table component.
Added a scoped CSS rule to remove the bottom border from the last row's cells (td) within the .ingredients-table.