### PR TITLE
Extracted Cocktail Card Component

### DIFF
--- a/src/components/CocktailCard.vue
+++ b/src/components/CocktailCard.vue
@@ -1,0 +1,103 @@
+<template>
+  <a-card class="h-full flex flex-col" :bodyStyle="{ flex: '1', display: 'flex', flexDirection: 'column' }">
+    <template #extra>
+      <a-dropdown trigger="click">
+        <a class="ant-dropdown-link" @click.prevent>
+          <MoreOutlined style="font-size: 20px; cursor: pointer" />
+        </a>
+        <template #overlay>
+          <a-menu>
+            <a-menu-item>
+              <router-link :to="`/cocktails/${recipe._id}/edit`">
+                <EditOutlined /> Редактировать
+              </router-link>
+            </a-menu-item>
+            <a-menu-item>
+              <router-link :to="`/instruction/${recipe._id}`">
+                <ReadOutlined /> Инструкция
+              </router-link>
+            </a-menu-item>
+            <a-menu-item danger>
+              <a-popconfirm
+                title="Удалить этот рецепт?"
+                ok-text="Да"
+                cancel-text="Нет"
+                @confirm="$emit('delete', recipe._id)"
+              >
+                <span><DeleteOutlined /> Удалить</span>
+              </a-popconfirm>
+            </a-menu-item>
+          </a-menu>
+        </template>
+      </a-dropdown>
+    </template>
+    <template #title>
+      <router-link :to="`/cocktails/${recipe._id}`" class="flex items-center gap-2">
+        <a-tag :color="recipe.category === 'Classic' ? 'blue' : 'purple'" :title="recipe.category">
+          {{ recipe.category[0] }}
+        </a-tag>
+        <span>{{ recipe.name }}</span>
+      </router-link>
+    </template>
+
+    <div class="flex-1">
+      <div class="mb-3">
+        <img
+          :src="recipe.image || placeholderImage"
+          alt="cocktail image"
+          class="w-full h-48 object-cover rounded"
+        />
+      </div>
+
+      <a-table
+        class="ingredients-table"
+        :columns="[
+          { title: 'Ингредиент', dataIndex: 'name', key: 'name' },
+          { title: 'Количество (мл)', dataIndex: 'amount', key: 'amount' }
+        ]"
+        :data-source="recipe.components"
+        size="small"
+        :pagination="false"
+        :showHeader="false"
+      />
+    </div>
+
+    <div class="mt-auto pt-4 border-t border-gray-200">
+      <div class="mb-2">
+        <strong>Метод:</strong>
+        <template v-if="Array.isArray(recipe.method)">
+          <a-tag v-for="m in recipe.method" :key="m" color="blue">{{ m }}</a-tag>
+        </template>
+        <span v-else>{{ recipe.method }}</span>
+      </div>
+      <div class="mb-2"><strong>Бокал:</strong> {{ recipe.glass }}</div>
+      <div>
+        <strong>Украшение:</strong>
+        <template v-if="Array.isArray(recipe.decoration)">
+          <a-tag v-for="d in recipe.decoration" :key="d" color="green">{{ d }}</a-tag>
+        </template>
+        <span v-else>{{ recipe.decoration }}</span>
+      </div>
+    </div>
+  </a-card>
+</template>
+
+<script setup>
+import { MoreOutlined, EditOutlined, ReadOutlined, DeleteOutlined } from "@ant-design/icons-vue"
+import placeholderImage from '../assets/cocktail_placeholder.png';
+
+defineProps({
+  recipe: {
+    type: Object,
+    required: true
+  }
+})
+
+defineEmits(['delete'])
+</script>
+
+<style scoped>
+.ingredients-table :deep(.ant-table-tbody > tr:last-child > td) {
+  border-bottom: none !important;
+}
+</style>

--- a/src/views/Cocktails.vue
+++ b/src/views/Cocktails.vue
@@ -20,87 +20,7 @@
 
     <a-row :gutter="[16, 16]">
       <a-col v-for="r in filteredRecipes" :key="r._id" :xs="24" :sm="12" :md="8">
-        <a-card class="h-full flex flex-col" :bodyStyle="{ flex: '1', display: 'flex', flexDirection: 'column' }">
-          <template #extra>
-            <a-dropdown trigger="click">
-              <a class="ant-dropdown-link" @click.prevent>
-                <MoreOutlined style="font-size: 20px; cursor: pointer" />
-              </a>
-              <template #overlay>
-                <a-menu>
-                  <a-menu-item>
-                    <router-link :to="`/cocktails/${r._id}/edit`">
-                      <EditOutlined /> Редактировать
-                    </router-link>
-                  </a-menu-item>
-                  <a-menu-item>
-                    <router-link :to="`/instruction/${r._id}`">
-                      <ReadOutlined /> Инструкция
-                    </router-link>
-                  </a-menu-item>
-                  <a-menu-item danger>
-                    <a-popconfirm
-                      title="Удалить этот рецепт?"
-                      ok-text="Да"
-                      cancel-text="Нет"
-                      @confirm="deleteRecipe(r._id)"
-                    >
-                      <span><DeleteOutlined /> Удалить</span>
-                    </a-popconfirm>
-                  </a-menu-item>
-                </a-menu>
-              </template>
-            </a-dropdown>
-          </template>
-          <template #title>
-            <router-link :to="`/cocktails/${r._id}`" class="flex items-center gap-2">
-              <a-tag :color="r.category === 'Classic' ? 'blue' : 'purple'" :title="r.category">
-                {{ r.category[0] }}
-              </a-tag>
-              <span>{{ r.name }}</span>
-            </router-link>
-          </template>
-
-          <div class="flex-1">
-            <div class="mb-3">
-              <img
-                :src="r.image || placeholderImage"
-                alt="cocktail image"
-                class="w-full h-48 object-cover rounded"
-              />
-            </div>
-
-            <a-table
-              class="ingredients-table"
-              :columns="[
-                { title: 'Ингредиент', dataIndex: 'name', key: 'name' },
-                { title: 'Количество (мл)', dataIndex: 'amount', key: 'amount' }
-              ]"
-              :data-source="r.components"
-              size="small"
-              :pagination="false"
-              :showHeader="false"
-            />
-          </div>
-
-          <div class="mt-auto pt-4 border-t border-gray-200">
-            <div class="mb-2">
-              <strong>Метод:</strong>
-              <template v-if="Array.isArray(r.method)">
-                <a-tag v-for="m in r.method" :key="m" color="blue">{{ m }}</a-tag>
-              </template>
-              <span v-else>{{ r.method }}</span>
-            </div>
-            <div class="mb-2"><strong>Бокал:</strong> {{ r.glass }}</div>
-            <div>
-              <strong>Украшение:</strong>
-              <template v-if="Array.isArray(r.decoration)">
-                <a-tag v-for="d in r.decoration" :key="d" color="green">{{ d }}</a-tag>
-              </template>
-              <span v-else>{{ r.decoration }}</span>
-            </div>
-          </div>
-        </a-card>
+        <CocktailCard :recipe="r" @delete="deleteRecipe" />
       </a-col>
     </a-row>
   </div>
@@ -110,11 +30,10 @@
 import { ref, onMounted } from "vue"
 import axios from "axios"
 import { message } from "ant-design-vue"
-import { MoreOutlined, EditOutlined, ReadOutlined, DeleteOutlined } from "@ant-design/icons-vue"
 import CocktailFilter from "../components/CocktailFilter.vue"
+import CocktailCard from "../components/CocktailCard.vue"
 import { RECIPES_URL } from '../config/api.js';
 import { useAuthStore } from '../stores/auth';
-import placeholderImage from '../assets/cocktail_placeholder.png';
 
 const recipes = ref([])
 const filteredRecipes = ref([])
@@ -171,8 +90,4 @@ const deleteRecipe = async (id) => {
 onMounted(fetchRecipes)
 </script>
 
-<style scoped>
-.ingredients-table :deep(.ant-table-tbody > tr:last-child > td) {
-  border-bottom: none !important;
-}
-</style>
+


### PR DESCRIPTION
I have refactored the cocktail list view by extracting the cocktail card into its own reusable component. This improves code organization and maintainability.

### Changes

**CocktailCard.vue:** Created a new component in src/components that encapsulates the UI and logic for a single cocktail card.
**Cocktails.vue:** Updated the view to import and use the CocktailCard component, removing the duplicated template code and styles.