### PR TITLE
Adjusted Ribbon Badge Position

### DIFF
--- a/src/components/CocktailCard.vue
+++ b/src/components/CocktailCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <a-badge-ribbon :text="recipe.category" :color="recipe.category === 'Classic' ? 'blue' : 'purple'">
+  <a-badge-ribbon :text="recipe.category" :color="recipe.category === 'Classic' ? 'blue' : 'purple'" :style="{ top: '71px' }">
     <a-card class="h-full flex flex-col" :bodyStyle="{ flex: '1', display: 'flex', flexDirection: 'column' }">
       <template #extra>
         <a-dropdown trigger="click">


### PR DESCRIPTION
I have adjusted the vertical position of the category ribbon badge on the cocktail cards to be 71 pixels from the top.

### Changes

**CocktailCard.vue:** Added inline style :style="{ top: '71px' }" to the a-badge-ribbon component.