### PR TITLE
Fixed Add Cocktail Error

### DIFF
--- a/src/views/AddCocktail.vue
+++ b/src/views/AddCocktail.vue
@@ -121,6 +121,7 @@ const router = useRouter()
 
 const components = ref([])
 const methods = ref([])
+const glasses = ref([])
 const decorations = ref([])
 
 const newRecipe = ref({


### PR DESCRIPTION
I have fixed the runtime error that occurred when navigating to the "Add Cocktail" page. The issue was caused by the glasses data property being undefined during the initial render.

### Changes

**AddCocktail.vue:** Initialized glasses as an empty array (ref([])) in the script setup. This ensures that the template can safely iterate over it even before the data is fetched from the API.