### PR TITLE
Refactored Cocktail Card Footer

### DIFF
--- a/src/components/CocktailCard.vue
+++ b/src/components/CocktailCard.vue
@@ -61,21 +61,17 @@
       </div>
 
       <div class="mt-auto pt-4 border-t border-gray-200">
-        <div class="mb-2">
-          <strong>Метод:</strong>
-          <template v-if="Array.isArray(recipe.method)">
-            <a-tag v-for="m in recipe.method" :key="m" color="blue">{{ m }}</a-tag>
-          </template>
-          <span v-else>{{ recipe.method }}</span>
-        </div>
-        <div class="mb-2"><strong>Бокал:</strong> {{ recipe.glass }}</div>
-        <div>
-          <strong>Украшение:</strong>
-          <template v-if="Array.isArray(recipe.decoration)">
-            <a-tag v-for="d in recipe.decoration" :key="d" color="green">{{ d }}</a-tag>
-          </template>
-          <span v-else>{{ recipe.decoration }}</span>
-        </div>
+        <a-descriptions size="small" :column="1" bordered>
+          <a-descriptions-item label="Метод">
+            {{ Array.isArray(recipe.method) ? recipe.method.join(', ') : recipe.method }}
+          </a-descriptions-item>
+          <a-descriptions-item label="Бокал">
+            {{ recipe.glass }}
+          </a-descriptions-item>
+          <a-descriptions-item label="Украшение">
+            {{ Array.isArray(recipe.decoration) ? recipe.decoration.join(', ') : recipe.decoration }}
+          </a-descriptions-item>
+        </a-descriptions>
       </div>
     </a-card>
   </a-badge-ribbon>


### PR DESCRIPTION
I have updated the cocktail card footer to use the Ant Design Descriptions component, providing a cleaner and more structured layout for the cocktail details.

### Changes

**CocktailCard.vue:**
Replaced the custom div-based footer with a-descriptions.
Configured a-descriptions-item to display "Method", "Glass", and "Decoration".
Applied bordered and size="small" props for a compact and organized look.
**Update:** Changed "Method" and "Decoration" to display as simple comma-separated text instead of tags, for a cleaner look.