### PR TITLE
Hidden Sidebar on Home Page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,13 @@
 <script setup>
 import EnvBadge from "./components/EnvBadge.vue";
 import { useAuthStore } from "./stores/auth";
-import { useRouter } from "vue-router";
+import { useRouter, useRoute } from "vue-router";
 import { onMounted, ref } from "vue";
 import { ShopOutlined } from '@ant-design/icons-vue';
 
 const authStore = useAuthStore();
 const router = useRouter();
+const route = useRoute();
 const openKeys = ref(['organization']);
 const collapsed = ref(true);
 
@@ -85,7 +86,7 @@ const handleLogout = () => {
 
     <a-layout>
       <a-layout-sider
-        v-if="authStore.isAuthenticated"
+        v-if="authStore.isAuthenticated && route.path !== '/'"
         collapsible
         v-model:collapsed="collapsed"
         theme="light"


### PR DESCRIPTION
I have updated the application layout to hide the sidebar navigation on the home page, ensuring a cleaner and more focused landing page experience.

### Changes

**App.vue:**
Imported useRoute from vue-router to access the current route information.
Updated the v-if condition on the <a-layout-sider> component to check if route.path is not equal to '/'.
This ensures the sidebar is only rendered on internal application pages (like /cocktails, /profile, etc.) and not on the public landing page.