### PR TITLE
Methods Page Refactor

### DIFF
--- a/src/components/AddMethodDrawer.vue
+++ b/src/components/AddMethodDrawer.vue
@@ -1,0 +1,106 @@
+<template>
+  <a-drawer
+    :title="methodToEdit ? 'Редактировать метод' : 'Добавить новый метод'"
+    :width="width"
+    :open="open"
+    :body-style="{ paddingBottom: '80px' }"
+    :footer-style="{ textAlign: 'right' }"
+    @close="onClose"
+  >
+    <a-form layout="vertical" :model="newMethod">
+      <a-form-item label="Название" required>
+        <a-input v-model:value="newMethod.name" placeholder="Введите название метода (например: Шейк)" />
+      </a-form-item>
+    </a-form>
+
+    <template #footer>
+      <a-space>
+        <a-button @click="onClose">Отмена</a-button>
+        <a-button type="primary" @click="handleSubmit" :loading="loading">
+          {{ methodToEdit ? 'Сохранить' : 'Добавить' }}
+        </a-button>
+      </a-space>
+    </template>
+  </a-drawer>
+</template>
+
+<script setup>
+import { ref, reactive, watch } from 'vue';
+import axios from 'axios';
+import { message } from 'ant-design-vue';
+import { METHODS_URL } from '../config/api.js';
+import { useAuthStore } from '../stores/auth';
+
+const props = defineProps({
+  open: Boolean,
+  width: {
+    type: [String, Number],
+    default: 600
+  },
+  methodToEdit: {
+    type: Object,
+    default: null
+  }
+});
+
+const emit = defineEmits(['update:open', 'methodAdded', 'methodUpdated']);
+
+const loading = ref(false);
+const newMethod = reactive({
+  name: ""
+});
+
+watch(() => props.methodToEdit, (newVal) => {
+  if (newVal) {
+    newMethod.name = newVal.name;
+  } else {
+    newMethod.name = "";
+  }
+}, { immediate: true });
+
+const onClose = () => {
+  emit('update:open', false);
+};
+
+const handleSubmit = async () => {
+  const authStore = useAuthStore();
+  if (!authStore.selectedVenue) return message.error("Venue not selected");
+  
+  if (!newMethod.name.trim()) {
+    return message.warning("Введите название");
+  }
+
+  loading.value = true;
+  try {
+    if (props.methodToEdit) {
+      await axios.put(`${METHODS_URL}/${props.methodToEdit._id}`, {
+        name: newMethod.name
+      }, {
+        headers: { Authorization: `Bearer ${authStore.token}` }
+      });
+      message.success("Метод обновлен!");
+      emit('methodUpdated');
+    } else {
+      await axios.post(METHODS_URL, {
+        name: newMethod.name,
+        venueId: authStore.selectedVenue._id
+      }, {
+        headers: { Authorization: `Bearer ${authStore.token}` }
+      });
+      message.success("Метод добавлен!");
+      emit('methodAdded');
+    }
+    
+    onClose();
+  } catch (e) {
+    console.error(e);
+    if (e.response?.status === 409) {
+      message.warning("Такой метод уже существует");
+    } else {
+      message.error("Ошибка при сохранении метода");
+    }
+  } finally {
+    loading.value = false;
+  }
+};
+</script>


### PR DESCRIPTION
I have refactored the Methods page to align with the design of the Cocktails and Components pages. The inline form has been replaced with a drawer, and the methods are now displayed in a responsive grid of cards.

### Changes

**AddMethodDrawer.vue:**

- Created a new component to handle adding and editing methods.
- Encapsulated the form logic, validation, and API calls within this drawer.
- Added responsive width behavior.

**CocktailMethods.vue:**

- Removed the old inline form and list.
- Added a header with an "Add Method" button that opens the drawer.
- Implemented a responsive grid layout using a-row and a-col.
- Each method is displayed in an a-card with a dropdown menu for "Edit" and "Delete" actions.