### PR TITLE
Decorations Page Refactor

### DIFF
--- a/src/components/AddDecorationDrawer.vue
+++ b/src/components/AddDecorationDrawer.vue
@@ -1,0 +1,106 @@
+<template>
+  <a-drawer
+    :title="decorationToEdit ? 'Редактировать украшение' : 'Добавить новое украшение'"
+    :width="width"
+    :open="open"
+    :body-style="{ paddingBottom: '80px' }"
+    :footer-style="{ textAlign: 'right' }"
+    @close="onClose"
+  >
+    <a-form layout="vertical" :model="newDecoration">
+      <a-form-item label="Название" required>
+        <a-input v-model:value="newDecoration.name" placeholder="Введите название украшения (например: Долька лимона)" />
+      </a-form-item>
+    </a-form>
+
+    <template #footer>
+      <a-space>
+        <a-button @click="onClose">Отмена</a-button>
+        <a-button type="primary" @click="handleSubmit" :loading="loading">
+          {{ decorationToEdit ? 'Сохранить' : 'Добавить' }}
+        </a-button>
+      </a-space>
+    </template>
+  </a-drawer>
+</template>
+
+<script setup>
+import { ref, reactive, watch } from 'vue';
+import axios from 'axios';
+import { message } from 'ant-design-vue';
+import { DECORATIONS_URL } from '../config/api.js';
+import { useAuthStore } from '../stores/auth';
+
+const props = defineProps({
+  open: Boolean,
+  width: {
+    type: [String, Number],
+    default: 600
+  },
+  decorationToEdit: {
+    type: Object,
+    default: null
+  }
+});
+
+const emit = defineEmits(['update:open', 'decorationAdded', 'decorationUpdated']);
+
+const loading = ref(false);
+const newDecoration = reactive({
+  name: ""
+});
+
+watch(() => props.decorationToEdit, (newVal) => {
+  if (newVal) {
+    newDecoration.name = newVal.name;
+  } else {
+    newDecoration.name = "";
+  }
+}, { immediate: true });
+
+const onClose = () => {
+  emit('update:open', false);
+};
+
+const handleSubmit = async () => {
+  const authStore = useAuthStore();
+  if (!authStore.selectedVenue) return message.error("Venue not selected");
+  
+  if (!newDecoration.name.trim()) {
+    return message.warning("Введите название");
+  }
+
+  loading.value = true;
+  try {
+    if (props.decorationToEdit) {
+      await axios.put(`${DECORATIONS_URL}/${props.decorationToEdit._id}`, {
+        name: newDecoration.name
+      }, {
+        headers: { Authorization: `Bearer ${authStore.token}` }
+      });
+      message.success("Украшение обновлено!");
+      emit('decorationUpdated');
+    } else {
+      await axios.post(DECORATIONS_URL, {
+        name: newDecoration.name,
+        venueId: authStore.selectedVenue._id
+      }, {
+        headers: { Authorization: `Bearer ${authStore.token}` }
+      });
+      message.success("Украшение добавлено!");
+      emit('decorationAdded');
+    }
+    
+    onClose();
+  } catch (e) {
+    console.error(e);
+    if (e.response?.status === 409) {
+      message.warning("Такое украшение уже существует");
+    } else {
+      message.error("Ошибка при сохранении украшения");
+    }
+  } finally {
+    loading.value = false;
+  }
+};
+</script>

--- a/src/views/CocktailDecorations.vue
+++ b/src/views/CocktailDecorations.vue
@@ -1,84 +1,96 @@
 <template>
-  <div>
-    <!-- Добавление нового украшения -->
-    <a-card class="mb-4" title="Добавить новое украшение">
-      <a-form layout="vertical" @submit.prevent="addDecoration">
-        <a-form-item label="Название">
-          <a-input
-            v-model:value="newDecoration.name"
-            placeholder="Введите название украшения (например: Долька лимона)"
-          />
-        </a-form-item>
-
-        <a-form-item>
-          <a-button type="primary" html-type="submit">Добавить</a-button>
-        </a-form-item>
-      </a-form>
-    </a-card>
+  <div class="p-6 max-w-5xl mx-auto">
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-2xl font-bold">Украшения</h1>
+      <a-button type="primary" @click="handleAdd">
+        <template #icon><PlusOutlined /></template>
+        Добавить украшение
+      </a-button>
+    </div>
 
     <!-- Список украшений -->
-    <a-card title="Список украшений">
-      <a-list bordered :data-source="decorations">
-        <template #renderItem="{ item }">
-          <a-list-item class="flex justify-between items-center">
-            <div class="flex items-center gap-2">
-              <template v-if="editingId === item._id">
-                <a-input
-                  v-model:value="editName"
-                  size="small"
-                  style="width: 200px"
-                  @pressEnter="saveEdit(item._id)"
-                  @blur="cancelEdit"
-                />
-                <a-button
-                  size="small"
-                  type="primary"
-                  @click="saveEdit(item._id)"
-                >
-                  OK
-                </a-button>
-                <a-button size="small" @click="cancelEdit">Отмена</a-button>
+    <a-row :gutter="[16, 16]">
+      <a-col v-for="item in decorations" :key="item._id" :xs="24" :sm="12" :md="8">
+        <a-card class="h-full flex flex-col" hoverable>
+          <template #extra>
+            <a-dropdown trigger="click">
+              <a class="ant-dropdown-link" @click.prevent>
+                <MoreOutlined style="font-size: 20px; cursor: pointer" />
+              </a>
+              <template #overlay>
+                <a-menu>
+                  <a-menu-item @click="handleEdit(item)">
+                    <EditOutlined /> Редактировать
+                  </a-menu-item>
+                  <a-menu-item danger>
+                    <a-popconfirm
+                      title="Удалить украшение?"
+                      ok-text="Да"
+                      cancel-text="Нет"
+                      @confirm="deleteDecoration(item._id)"
+                    >
+                      <span><DeleteOutlined /> Удалить</span>
+                    </a-popconfirm>
+                  </a-menu-item>
+                </a-menu>
               </template>
+            </a-dropdown>
+          </template>
+          <template #title>
+            <span class="text-lg">{{ item.name }}</span>
+          </template>
+        </a-card>
+      </a-col>
+    </a-row>
 
-              <template v-else>
-                <span
-                  class="cursor-pointer hover:underline"
-                  @click="startEdit(item)"
-                >
-                  {{ item.name }}
-                </span>
-              </template>
-            </div>
-
-            <a-popconfirm
-              title="Удалить украшение?"
-              ok-text="Да"
-              cancel-text="Нет"
-              @confirm="deleteDecoration(item._id)"
-            >
-              <a-button type="text" danger>
-                <DeleteOutlined />
-              </a-button>
-            </a-popconfirm>
-          </a-list-item>
-        </template>
-      </a-list>
-    </a-card>
+    <AddDecorationDrawer
+      v-model:open="showAddDrawer"
+      :width="drawerWidth"
+      :decorationToEdit="editingDecoration"
+      @decorationAdded="fetchDecorations"
+      @decorationUpdated="fetchDecorations"
+    />
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from "vue";
+import { ref, onMounted, onUnmounted } from "vue";
 import axios from "axios";
 import { message } from "ant-design-vue";
-import { DeleteOutlined } from "@ant-design/icons-vue";
+import { PlusOutlined, DeleteOutlined, MoreOutlined, EditOutlined } from "@ant-design/icons-vue";
 import { DECORATIONS_URL } from '../config/api.js';
 import { useAuthStore } from '../stores/auth';
+import AddDecorationDrawer from '../components/AddDecorationDrawer.vue';
 
 const decorations = ref([]);
-const newDecoration = ref({ name: "" });
-const editingId = ref(null);
-const editName = ref("");
+const showAddDrawer = ref(false);
+const drawerWidth = ref('600px');
+const editingDecoration = ref(null);
+
+// Responsive drawer width
+const updateDrawerWidth = () => {
+  drawerWidth.value = window.innerWidth < 640 ? '100%' : '600px';
+};
+
+const handleAdd = () => {
+  editingDecoration.value = null;
+  showAddDrawer.value = true;
+};
+
+const handleEdit = (item) => {
+  editingDecoration.value = item;
+  showAddDrawer.value = true;
+};
+
+onMounted(() => {
+  updateDrawerWidth();
+  window.addEventListener('resize', updateDrawerWidth);
+  fetchDecorations();
+});
+
+onUnmounted(() => {
+  window.removeEventListener('resize', updateDrawerWidth);
+});
 
 // ===== Загрузка списка =====
 const fetchDecorations = async () => {
@@ -97,37 +109,6 @@ const fetchDecorations = async () => {
   }
 };
 
-// ===== Добавление =====
-const addDecoration = async () => {
-  const authStore = useAuthStore();
-  if (!authStore.selectedVenue) return message.error("Venue not selected");
-
-  const name = newDecoration.value.name.trim();
-  if (!name) return message.warning("Введите название");
-
-  const exists = decorations.value.some(
-    (d) => d.name.toLowerCase() === name.toLowerCase()
-  );
-  if (exists) return message.warning("Такое украшение уже существует");
-
-  try {
-    await axios.post(DECORATIONS_URL, { 
-      name,
-      venueId: authStore.selectedVenue._id 
-    }, {
-      headers: { Authorization: `Bearer ${authStore.token}` }
-    });
-    message.success("Украшение добавлено");
-    newDecoration.value.name = "";
-    await fetchDecorations();
-  } catch (e) {
-    console.error(e);
-    if (e.response?.status === 409)
-      message.warning("Такое украшение уже существует");
-    else message.error("Ошибка при добавлении украшения");
-  }
-};
-
 // ===== Удаление =====
 const deleteDecoration = async (id) => {
   const authStore = useAuthStore();
@@ -142,52 +123,4 @@ const deleteDecoration = async (id) => {
     message.error("Ошибка при удалении украшения");
   }
 };
-
-// ===== Редактирование =====
-const startEdit = (item) => {
-  editingId.value = item._id;
-  editName.value = item.name;
-};
-
-const cancelEdit = () => {
-  editingId.value = null;
-  editName.value = "";
-};
-
-const saveEdit = async (id) => {
-  const newName = editName.value.trim();
-  if (!newName) return message.warning("Введите название");
-
-  const exists = decorations.value.some(
-    (d) => d._id !== id && d.name.toLowerCase() === newName.toLowerCase()
-  );
-  if (exists) return message.warning("Такое украшение уже существует");
-
-  try {
-    const authStore = useAuthStore();
-    await axios.put(`${DECORATIONS_URL}/${id}`, { name: newName }, {
-      headers: { Authorization: `Bearer ${authStore.token}` }
-    });
-    message.success("Изменения сохранены");
-    cancelEdit();
-    await fetchDecorations();
-  } catch (e) {
-    console.error(e);
-    message.error("Ошибка при сохранении украшения");
-  }
-};
-
-onMounted(fetchDecorations);
 </script>
-
-<style scoped>
-.mb-4 {
-  margin-bottom: 16px;
-}
-.cursor-pointer {
-  cursor: pointer;
-}
-.hover\:underline:hover {
-  text-decoration: underline;
-}
-</style>


### PR DESCRIPTION
I have refactored the Decorations page to align with the design of the other management pages. The inline form has been replaced with a drawer, and the decorations are now displayed in a responsive grid of cards.

### Changes

**AddDecorationDrawer.vue:**

- Created a new component to handle adding and editing decorations.
- Encapsulated the form logic, validation, and API calls within this drawer.
- Added responsive width behavior.

**CocktailDecorations.vue:**

- Removed the old inline form and list.
- Added a header with an "Add Decoration" button that opens the drawer.
- Implemented a responsive grid layout using a-row and a-col.
- Each decoration is displayed in an a-card with a dropdown menu for "Edit" and "Delete" actions.