### PR TITLE
Bar Page Implementation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -40,8 +40,10 @@ const handleLogout = () => {
               Дашборд
             </router-link>
           </a-menu-item>
-          <a-sub-menu key="bar" v-if="authStore.selectedVenue">
-            <template #title>Бар</template>
+          <a-sub-menu key="bar" v-if="authStore.selectedVenue" @titleClick="router.push('/bar')">
+            <template #title>
+              <span class="cursor-pointer">Бар</span>
+            </template>
             <a-menu-item key="cocktails">
               <router-link to="/cocktails">Коктейли</router-link>
             </a-menu-item>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -64,6 +64,12 @@ const routes = [
     component: () => import("../views/ComponentView.vue"),
   },
   {
+    path: "/bar",
+    name: "Bar",
+    component: () => import("../views/Bar.vue"),
+    meta: { requiresAuth: true },
+  },
+  {
     path: "/dashboard",
     name: "Dashboard",
     component: () => import("../views/Dashboard.vue"),

--- a/src/views/Bar.vue
+++ b/src/views/Bar.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="p-6 max-w-7xl mx-auto">
+    <h1 class="text-3xl font-bold mb-8">Управление баром</h1>
+    
+    <a-row :gutter="[24, 24]">
+      <a-col :xs="24" :sm="12" :md="8" v-for="item in menuItems" :key="item.path">
+        <router-link :to="item.path" class="block h-full">
+          <a-card hoverable class="h-full transition-transform hover:-translate-y-1">
+            <template #cover>
+              <div class="h-32 bg-gray-100 flex items-center justify-center text-4xl text-gray-400">
+                <component :is="item.icon" />
+              </div>
+            </template>
+            <a-card-meta :title="item.title">
+              <template #description>
+                {{ item.description }}
+              </template>
+            </a-card-meta>
+          </a-card>
+        </router-link>
+      </a-col>
+    </a-row>
+  </div>
+</template>
+
+<script setup>
+import { 
+  ExperimentOutlined, 
+  AppstoreOutlined, 
+  BuildOutlined, 
+  CoffeeOutlined, 
+  ScissorOutlined, 
+  PlayCircleOutlined 
+} from '@ant-design/icons-vue';
+
+const menuItems = [
+  {
+    title: 'Коктейли',
+    description: 'Управление рецептами коктейлей, создание новых и редактирование существующих.',
+    path: '/cocktails',
+    icon: ExperimentOutlined
+  },
+  {
+    title: 'Компоненты',
+    description: 'База ингредиентов и компонентов для приготовления напитков.',
+    path: '/cocktailComponents',
+    icon: AppstoreOutlined
+  },
+  {
+    title: 'Методы',
+    description: 'Справочник методов приготовления (шейк, стир, билд и другие).',
+    path: '/cocktailMethods',
+    icon: BuildOutlined
+  },
+  {
+    title: 'Бокалы',
+    description: 'Типы бокалов и посуды подачи.',
+    path: '/cocktailGlasses',
+    icon: CoffeeOutlined
+  },
+  {
+    title: 'Украшения',
+    description: 'Украшения и гарниши для подачи коктейлей.',
+    path: '/cocktailDecorations',
+    icon: ScissorOutlined
+  },
+  {
+    title: 'Коктейль-игра',
+    description: 'Интерактивная игра для обучения и проверки знаний рецептов.',
+    path: '/cocktail-game',
+    icon: PlayCircleOutlined
+  }
+];
+</script>


### PR DESCRIPTION
I have implemented a new "Bar" landing page that serves as a central hub for all bar management sections. The "Bar" item in the header menu is now clickable and navigates to this page.

### Changes

**Bar.vue:**

- Created a new view with a grid of cards linking to:
- Cocktails
- Components
- Methods
- Glasses
- Decorations
- Cocktail Game
- Each card includes an icon and a brief description.

**router/index.js:**

- Added the /bar route.

**App.vue:**

- Updated the "Bar" a-sub-menu to handle @titleClick, navigating to /bar.
- Added cursor-pointer class to the title span to indicate interactivity.